### PR TITLE
모바일 검색과 이미지 렌더링 개선

### DIFF
--- a/components/BlogShell.tsx
+++ b/components/BlogShell.tsx
@@ -48,10 +48,10 @@ export default function BlogShell({ categoryGroups, children }: BlogShellProps) 
           >
             <Image alt="" aria-hidden="true" height={24} src="/menu-icon.svg" width={24} />
           </button>
-          <Link href="/">yuyeol3.github.io</Link>
+          <Link className="blog-title" href="/">yuyeol3.github.io</Link>
         </div>
         <div className="header-right">
-          <Link aria-label="게시글 검색" href="/search/">
+          <Link aria-label="게시글 검색" className="search-button" href="/search/">
             <Image alt="" aria-hidden="true" height={24} src="/search-icon.svg" width={24} />
           </Link>
         </div>

--- a/components/post/MarkdownContent.tsx
+++ b/components/post/MarkdownContent.tsx
@@ -8,6 +8,8 @@ import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 
+import { getLocalImageDimensions } from "@/lib/image-dimensions";
+
 interface MarkdownContentProps {
   markdown: string;
 }
@@ -55,6 +57,14 @@ export default function MarkdownContent({ markdown }: MarkdownContentProps) {
       ) : (
         <code className={className}>{children}</code>
       );
+    },
+    img({ alt, node, src, ...props }) {
+      void node;
+      const dimensions = getLocalImageDimensions(typeof src === "string" ? src : undefined);
+
+      // Markdown supports arbitrary remote URLs, which cannot always use next/image safely.
+      // eslint-disable-next-line @next/next/no-img-element
+      return <img alt={alt ?? ""} {...props} {...dimensions} src={src} />;
     },
     h1: heading(1, slugger),
     h2: heading(2, slugger),

--- a/lib/image-dimensions.ts
+++ b/lib/image-dimensions.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { imageSize } from "image-size";
+
+interface ImageDimensions {
+  height: number;
+  width: number;
+}
+
+const publicDirectory = path.join(process.cwd(), "public");
+
+export function getLocalImageDimensions(source: string | undefined): ImageDimensions | undefined {
+  if (!source?.startsWith("/images/")) {
+    return undefined;
+  }
+
+  const sourcePath = source.split(/[?#]/, 1)[0];
+  let decodedPath: string;
+
+  try {
+    decodedPath = decodeURIComponent(sourcePath);
+  } catch {
+    return undefined;
+  }
+
+  const imagePath = path.resolve(publicDirectory, decodedPath.replace(/^\/+/, ""));
+  const relativePath = path.relative(publicDirectory, imagePath);
+
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath) || !fs.existsSync(imagePath)) {
+    return undefined;
+  }
+
+  const dimensions = imageSize(fs.readFileSync(imagePath));
+  if (!dimensions.width || !dimensions.height) {
+    return undefined;
+  }
+
+  return { height: dimensions.height, width: dimensions.width };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "github-slugger": "^2.0.0",
         "gray-matter": "^4.0.3",
+        "image-size": "^2.0.2",
         "katex": "^0.16.22",
         "next": "^16.3.0",
         "react": "^19.2.8",
@@ -4714,6 +4715,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "gray-matter": "^4.0.3",
     "github-slugger": "^2.0.0",
+    "gray-matter": "^4.0.3",
+    "image-size": "^2.0.2",
     "katex": "^0.16.22",
     "next": "^16.3.0",
     "react": "^19.2.8",

--- a/scripts/check-export.mjs
+++ b/scripts/check-export.mjs
@@ -22,6 +22,17 @@ function requireFile(filePath) {
   }
 }
 
+function getLocalImageTags(exportedPost) {
+  return exportedPost.match(/<img\b(?=[^>]*\bsrc="\/images\/)[^>]*>/gi) ?? [];
+}
+
+function requirePrerenderedImageSize(imageTag, relativePath) {
+  if (!/\bwidth="\d+"/.test(imageTag) || !/\bheight="\d+"/.test(imageTag)) {
+    const imageSource = imageTag.match(/\bsrc="([^"]+)"/i)?.[1] ?? "unknown image";
+    throw new Error(`Local image is missing prerendered dimensions: ${relativePath} (${imageSource})`);
+  }
+}
+
 for (const relativePath of ["index.html", "404.html", "sitemap.xml", "robots.txt", ".nojekyll"]) {
   requireFile(path.join(outDirectory, relativePath));
 }
@@ -39,6 +50,10 @@ for (const filePath of markdownFiles) {
   const exportedPost = fs.readFileSync(exportedPostPath, "utf8");
   if (!exportedPost.includes('class="post-header"')) {
     throw new Error(`Exported post is missing its rendered content: ${relativePath}`);
+  }
+
+  for (const imageTag of getLocalImageTags(exportedPost)) {
+    requirePrerenderedImageSize(imageTag, relativePath);
   }
   categoryCounts.set(category, (categoryCounts.get(category) ?? 0) + 1);
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -34,6 +34,36 @@
     justify-content: center;
 }
 
+.header .header-left {
+    min-width: 0;
+}
+
+.header .blog-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.header .search-button {
+    width: 44px;
+    height: 44px;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    font-size: 0;
+}
+
+.header .search-button:hover {
+    background-color: #f3f4f6;
+}
+
+.header .search-button:focus-visible {
+    outline: 2px solid #0077cc;
+    outline-offset: 2px;
+}
+
 .header a:hover {
     color: #0077cc;
 }
@@ -124,7 +154,11 @@
     border: none;              /* 기본 테두리 제거 */
     cursor: pointer;           /* 마우스 커서 변경 */
     transition: background-color 0.3s ease, transform 0.2s ease; /* 전환 효과 */
-    margin-right: 10px;
+    width: 44px;
+    height: 44px;
+    padding: 0;
+    border-radius: 8px;
+    margin-right: 4px;
     /*height: 10px;*/
 
     display: flex;
@@ -162,6 +196,14 @@
 
 /* 반응형 디자인 (화면이 작을 때) */
 @media (max-width: 900px) {
+    .header {
+        padding: 0.5rem 0.75rem;
+    }
+
+    .header .blog-title {
+        font-size: 1.1rem;
+    }
+
     .contents {
         max-width: 100%;
         width: 100%;

--- a/styles/board.css
+++ b/styles/board.css
@@ -94,6 +94,9 @@
     font-size: 14px;
     transition: border-color 0.2s ease;
     flex: 1;
+    min-width: 0;
+    height: 44px;
+    box-sizing: border-box;
 }
 
 .search-bar-input:focus {
@@ -110,6 +113,9 @@
     cursor: pointer;
     border-radius: 0 4px 4px 0;    /* 오른쪽 모서리 둥글게 */
     transition: background-color 0.3s ease, transform 0.2s ease;
+    height: 44px;
+    box-sizing: border-box;
+    flex-shrink: 0;
 
 }
 
@@ -141,6 +147,12 @@
 @media (max-width: 900px) {
     .search-bar form{
         width: 80%;
+    }
+}
+
+@media (max-width: 480px) {
+    .search-bar form {
+        width: 100%;
     }
 }
 

--- a/styles/post.css
+++ b/styles/post.css
@@ -75,6 +75,10 @@
     min-height: 50vh;
 }
 
+.markdown-body img {
+    height: auto;
+}
+
 .post-footer {
     min-height: 400px;
     margin-bottom: 100px;


### PR DESCRIPTION
모바일 검색 버튼과 검색 폼의 터치 영역 및 반응형 레이아웃을 개선했습니다. 로컬 게시글 이미지는 빌드 시 실제 크기를 HTML에 포함하고 정적 export 검사로 누락을 방지합니다. 검증: npm run lint, npm run typecheck, npm run build