### PR TITLE
PC 상단바 높이 조정

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -15,7 +15,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 1rem;
+    padding: 0.375rem 1rem;
     background-color: #ffffff;
     border-bottom: 1px solid #ddd;
 


### PR DESCRIPTION
데스크톱 헤더의 상하 여백을 줄여 전체 높이를 77px에서 57px로 조정했습니다. 메뉴와 검색 버튼의 44px 클릭 영역 및 모바일 헤더 크기는 유지합니다. 검증: npm run lint, npm run typecheck, npm run build, 로컬 브라우저 실측