### PR TITLE
상단바 높이 통일

### DIFF
--- a/styles/app.css
+++ b/styles/app.css
@@ -15,7 +15,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 0.375rem 1rem;
+    padding: 0.5rem 1rem;
     background-color: #ffffff;
     border-bottom: 1px solid #ddd;
 


### PR DESCRIPTION
데스크톱과 작은 화면의 상단바 세로 여백을 0.5rem으로 통일해 모두 61px 높이로 표시되도록 조정했습니다. 좌우 여백과 44px 버튼 영역은 기존 반응형 설정을 유지합니다. 검증: npm run lint, npm run typecheck, npm run build, 로컬 브라우저 실측