### PR TITLE
페이지 이동 시 스크롤 위치 초기화

### DIFF
--- a/components/BlogShell.tsx
+++ b/components/BlogShell.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
 import { useEffect, useState, type ReactNode } from "react";
 
 import type { CategoryGroup } from "@/lib/posts";
@@ -13,6 +14,12 @@ interface BlogShellProps {
 
 export default function BlogShell({ categoryGroups, children }: BlogShellProps) {
   const [menuOpen, setMenuOpen] = useState<boolean | null>(null);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    document.documentElement.scrollTop = 0;
+    document.body.scrollTop = 0;
+  }, [pathname]);
 
   useEffect(() => {
     const mediaQuery = window.matchMedia("(max-width: 900px)");


### PR DESCRIPTION
페이지 이동 후 화면이 상단바 아래 약 93px 지점에 멈추던 문제를 수정했습니다. 경로가 바뀌면 문서 스크롤을 정확히 최상단으로 맞춥니다.

검증: 브라우저에서 632px 위치에서 게시글 이동 후 0px 확인, npm run lint, npm run typecheck, npm run build