### PR TITLE
다크 모드 추가

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,16 @@ import "@/styles/app.css";
 import "@/styles/board.css";
 import "@/styles/markdown.css";
 import "@/styles/post.css";
+import "@/styles/theme.css";
+
+const themeInitScript = `
+  (() => {
+    const savedTheme = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    document.documentElement.dataset.theme =
+      savedTheme === "dark" || (!savedTheme && prefersDark) ? "dark" : "light";
+  })();
+`;
 
 export const metadata: Metadata = {
   description: SITE_DESCRIPTION,
@@ -22,7 +32,10 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
-    <html lang="ko">
+    <html lang="ko" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body>
         <BlogShell categoryGroups={getCategoryGroups()}>{children}</BlogShell>
       </body>

--- a/components/BlogShell.tsx
+++ b/components/BlogShell.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useEffect, useState, type ReactNode } from "react";
 
+import ThemeToggle from "@/components/ThemeToggle";
 import type { CategoryGroup } from "@/lib/posts";
 
 interface BlogShellProps {
@@ -58,6 +59,7 @@ export default function BlogShell({ categoryGroups, children }: BlogShellProps) 
           <Link className="blog-title" href="/">yuyeol3.github.io</Link>
         </div>
         <div className="header-right">
+          <ThemeToggle />
           <Link aria-label="게시글 검색" className="search-button" href="/search/">
             <Image alt="" aria-hidden="true" height={24} src="/search-icon.svg" width={24} />
           </Link>

--- a/components/Comments.tsx
+++ b/components/Comments.tsx
@@ -8,6 +8,10 @@ interface CommentsProps {
 
 type CommentStatus = "idle" | "loading" | "ready" | "failed";
 
+function getUtterancesTheme() {
+  return document.documentElement.dataset.theme === "dark" ? "github-dark" : "github-light";
+}
+
 export default function Comments({ term }: CommentsProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const commentsRef = useRef<HTMLDivElement>(null);
@@ -45,13 +49,32 @@ export default function Comments({ term }: CommentsProps) {
     script.src = "https://utteranc.es/client.js";
     script.setAttribute("issue-term", term);
     script.setAttribute("repo", "yuyeol3/yuyeol3.github.io");
-    script.setAttribute("theme", "github-light");
+    script.setAttribute("theme", getUtterancesTheme());
     script.onload = () => setStatus("ready");
     script.onerror = () => setStatus("failed");
     container.appendChild(script);
 
     return () => script.remove();
   }, [status, term]);
+
+  useEffect(() => {
+    const updateTheme = () => {
+      const iframe = commentsRef.current?.querySelector("iframe");
+
+      iframe?.contentWindow?.postMessage(
+        { theme: getUtterancesTheme(), type: "set-theme" },
+        "https://utteranc.es",
+      );
+    };
+    const observer = new MutationObserver(updateTheme);
+
+    observer.observe(document.documentElement, {
+      attributeFilter: ["data-theme"],
+      attributes: true,
+    });
+
+    return () => observer.disconnect();
+  }, []);
 
   return (
     <div className="comments-wrapper" ref={wrapperRef}>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+export default function ThemeToggle() {
+  function toggleTheme() {
+    const root = document.documentElement;
+    const nextTheme = root.dataset.theme === "dark" ? "light" : "dark";
+
+    root.dataset.theme = nextTheme;
+    localStorage.setItem("theme", nextTheme);
+  }
+
+  return (
+    <button
+      aria-label="색상 모드 전환"
+      className="theme-button"
+      onClick={toggleTheme}
+      title="색상 모드 전환"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        className="theme-icon theme-icon--moon"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <path
+          d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79Z"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+        />
+      </svg>
+      <svg
+        aria-hidden="true"
+        className="theme-icon theme-icon--sun"
+        fill="none"
+        height="24"
+        viewBox="0 0 24 24"
+        width="24"
+      >
+        <circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="2" />
+        <path
+          d="M12 2V4M12 20V22M4.93 4.93L6.34 6.34M17.66 17.66L19.07 19.07M2 12H4M20 12H22M4.93 19.07L6.34 17.66M17.66 6.34L19.07 4.93"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeWidth="2"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/components/post/MarkdownContent.tsx
+++ b/components/post/MarkdownContent.tsx
@@ -1,4 +1,4 @@
-import React, { isValidElement, type ReactNode } from "react";
+import React, { isValidElement, type CSSProperties, type ReactNode } from "react";
 import ReactMarkdown, { type Components } from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { prism as codeStyle } from "react-syntax-highlighter/dist/esm/styles/prism";
@@ -13,6 +13,46 @@ import { getLocalImageDimensions } from "@/lib/image-dimensions";
 interface MarkdownContentProps {
   markdown: string;
 }
+
+const syntaxColorVariables: Record<string, string> = {
+  "#07a": "var(--syntax-keyword)",
+  "#690": "var(--syntax-string)",
+  "#905": "var(--syntax-number)",
+  "#999": "var(--syntax-punctuation)",
+  "#9a6e3a": "var(--syntax-operator)",
+  "#DD4A68": "var(--syntax-function)",
+  "#e90": "var(--syntax-variable)",
+  black: "var(--code-text)",
+  slategray: "var(--syntax-comment)",
+};
+
+const customCodeStyle = Object.fromEntries(
+  Object.entries(codeStyle).map(([token, style]) => {
+    const color = typeof style.color === "string" ? syntaxColorVariables[style.color] : undefined;
+    const transparentBackground = style.background === "hsla(0, 0%, 100%, .5)";
+
+    return [
+      token,
+      {
+        ...style,
+        ...(color ? { color } : {}),
+        ...(transparentBackground ? { background: "transparent" } : {}),
+      },
+    ];
+  }),
+) as Record<string, CSSProperties>;
+
+customCodeStyle['pre[class*="language-"]'] = {
+  ...customCodeStyle['pre[class*="language-"]'],
+  background: "var(--code-block-background)",
+  color: "var(--code-text)",
+  textShadow: "none",
+};
+customCodeStyle['code[class*="language-"]'] = {
+  ...customCodeStyle['code[class*="language-"]'],
+  color: "var(--code-text)",
+  textShadow: "none",
+};
 
 function nodeToText(node: ReactNode): string {
   if (typeof node === "string" || typeof node === "number") {
@@ -39,13 +79,6 @@ function heading(level: 1 | 2 | 3 | 4 | 5 | 6, slugger: GithubSlugger) {
 
 export default function MarkdownContent({ markdown }: MarkdownContentProps) {
   const slugger = new GithubSlugger();
-  const customCodeStyle = {
-    ...codeStyle,
-    'pre[class*="language-"]': {
-      ...codeStyle['pre[class*="language-"]'],
-      background: "#f6f8fa",
-    },
-  };
   const components: Components = {
     code({ children, className }) {
       const language = /language-(\w+)/.exec(className ?? "")?.[1];

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,0 +1,191 @@
+:root {
+  color-scheme: light;
+  --code-block-background: #f6f8fa;
+  --code-text: #1f2328;
+  --syntax-comment: slategray;
+  --syntax-function: #dd4a68;
+  --syntax-keyword: #07a;
+  --syntax-number: #905;
+  --syntax-operator: #9a6e3a;
+  --syntax-punctuation: #999;
+  --syntax-string: #690;
+  --syntax-variable: #e90;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+  --code-block-background: #161b22;
+  --code-text: #e6edf3;
+  --syntax-comment: #8b949e;
+  --syntax-function: #d2a8ff;
+  --syntax-keyword: #ff7b72;
+  --syntax-number: #79c0ff;
+  --syntax-operator: #d2a8ff;
+  --syntax-punctuation: #c9d1d9;
+  --syntax-string: #a5d6ff;
+  --syntax-variable: #ffa657;
+}
+
+.theme-button {
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #333;
+  background: transparent;
+  cursor: pointer;
+}
+
+.theme-button:hover {
+  background-color: #f3f4f6;
+  color: #0077cc;
+}
+
+.theme-button:focus-visible {
+  outline: 2px solid #0077cc;
+  outline-offset: 2px;
+}
+
+.theme-icon--sun {
+  display: none;
+}
+
+html[data-theme="dark"] .theme-icon--moon {
+  display: none;
+}
+
+html[data-theme="dark"] .theme-icon--sun {
+  display: block;
+}
+
+html[data-theme="dark"],
+html[data-theme="dark"] body,
+html[data-theme="dark"] .App {
+  background-color: #0d1117;
+  color: #e6edf3;
+}
+
+html[data-theme="dark"] .header,
+html[data-theme="dark"] .side-bar,
+html[data-theme="dark"] .footer {
+  background-color: #161b22;
+  border-color: #30363d;
+}
+
+html[data-theme="dark"] .contents,
+html[data-theme="dark"] .board,
+html[data-theme="dark"] .markdown-body {
+  background-color: #0d1117;
+  color: #e6edf3;
+}
+
+html[data-theme="dark"] .header a,
+html[data-theme="dark"] .theme-button,
+html[data-theme="dark"] .side-bar h3,
+html[data-theme="dark"] .sidebar-item,
+html[data-theme="dark"] .button-area span[aria-current="page"] {
+  color: #e6edf3;
+}
+
+html[data-theme="dark"] .header img {
+  filter: invert(1);
+}
+
+html[data-theme="dark"] .header a:hover,
+html[data-theme="dark"] .theme-button:hover,
+html[data-theme="dark"] .table-of-contents a,
+html[data-theme="dark"] .markdown-body a {
+  color: #58a6ff;
+}
+
+html[data-theme="dark"] .header .search-button:hover,
+html[data-theme="dark"] .theme-button:hover,
+html[data-theme="dark"] .sidebar-item:hover {
+  background-color: #21262d;
+}
+
+html[data-theme="dark"] .post-preview,
+html[data-theme="dark"] .table-of-contents {
+  background-color: #161b22;
+  border-color: #30363d;
+  color: #e6edf3;
+}
+
+html[data-theme="dark"] .post-preview:hover {
+  box-shadow: 0 2px 8px rgb(0 0 0 / 45%);
+}
+
+html[data-theme="dark"] .board h1,
+html[data-theme="dark"] .hr,
+html[data-theme="dark"] .markdown-body h1,
+html[data-theme="dark"] .markdown-body h2,
+html[data-theme="dark"] .markdown-body .footnotes {
+  border-color: #30363d;
+}
+
+html[data-theme="dark"] .search-bar-input {
+  color: #e6edf3;
+  background-color: #0d1117;
+  border-color: #30363d;
+}
+
+html[data-theme="dark"] .search-bar-input::placeholder,
+html[data-theme="dark"] .not-found,
+html[data-theme="dark"] .loading,
+html[data-theme="dark"] .markdown-body h6,
+html[data-theme="dark"] .markdown-body blockquote,
+html[data-theme="dark"] .markdown-body .footnotes {
+  color: #8b949e;
+}
+
+html[data-theme="dark"] .markdown-body blockquote {
+  border-color: #30363d;
+}
+
+html[data-theme="dark"] .markdown-body hr {
+  background-color: #30363d;
+  border-color: #30363d;
+}
+
+html[data-theme="dark"] .markdown-body mark {
+  color: #e6edf3;
+  background-color: #5a4600;
+}
+
+html[data-theme="dark"] .markdown-body code,
+html[data-theme="dark"] .markdown-body tt,
+html[data-theme="dark"] .markdown-body kbd,
+html[data-theme="dark"] .markdown-body pre {
+  color: #e6edf3;
+  background-color: #161b22;
+  border-color: #30363d;
+  box-shadow: none;
+}
+
+html[data-theme="dark"] .markdown-body table td,
+html[data-theme="dark"] .markdown-body table th {
+  border-color: #30363d;
+}
+
+html[data-theme="dark"] .markdown-body table tr {
+  background-color: #0d1117;
+  border-color: #30363d;
+}
+
+html[data-theme="dark"] .markdown-body table tr:nth-child(2n) {
+  background-color: #161b22;
+}
+
+html[data-theme="dark"] .float-menu button {
+  color: #e6edf3;
+  background-color: rgb(48 54 61 / 85%);
+}
+
+html[data-theme="dark"] .float-menu button:hover {
+  background-color: #484f58;
+}


### PR DESCRIPTION
운영체제 색상 설정을 따르는 다크 모드와 상단바 전환 버튼을 추가했습니다. 사용자의 선택은 브라우저에 유지되며, 본문·목차·표·코드 강조·댓글·반응형 상단바까지 테마가 적용됩니다.

검증: 테마 전환 및 새로고침 유지, 623px 반응형 가로 넘침 없음, npm run lint, npm run typecheck, npm run build